### PR TITLE
Cuda status beautify

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,9 @@ cmake_minimum_required(VERSION 3.12) # Don't bump this version for no reason
 # If CUDA toolkit is not found using msvc compiler switch to Community Edition (same compiler, just other kit..)
 project("ggllm.cpp" C CXX)
 add_definitions(-DGGML_PERF=1) # use "--debug-timings 1-3" to enable timing output
-include_directories("C:/program files/NVIDIA GPU Computing Toolkit/CUDA/v12.0/include")
-include_directories("C:/program files/NVIDIA GPU Computing Toolkit/CUDA/v12.0/lib/x64")
+# include_directories("C:/program files/NVIDIA GPU Computing Toolkit/CUDA/v12.0/include")
+# include_directories("C:/program files/NVIDIA GPU Computing Toolkit/CUDA/v12.0/lib/x64")
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 if (NOT XCODE AND NOT MSVC AND NOT CMAKE_BUILD_TYPE)

--- a/Makefile
+++ b/Makefile
@@ -50,12 +50,12 @@ CXXFLAGS = -I. -I./examples $(OPT) -std=c++11 -fPIC
 LDFLAGS  =
 
 ifdef LLAMA_DEBUG
-	CFLAGS   += -O0 -g
-	CXXFLAGS += -O0 -g
+	CFLAGS   += -O0 -g -DGGML_PERF=1
+	CXXFLAGS += -O0 -g -DGGML_PERF=1
 	LDFLAGS  += -g
 else
-	CFLAGS   += -DNDEBUG
-	CXXFLAGS += -DNDEBUG
+	CFLAGS   += -DNDEBUG -DGGML_PERF=1
+	CXXFLAGS += -DNDEBUG -DGGML_PERF=1
 endif
 
 # warnings

--- a/examples/falcon_common.cpp
+++ b/examples/falcon_common.cpp
@@ -329,6 +329,7 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
                     params.tensor_split[i] = 0.0f;
                 }
             }
+            ggml_cuda_set_tensor_split_prepare(params.tensor_split,split_arg.size());
 #else
       fprintf(stderr, "warning: falcon.cpp was compiled without cuBLAS. It is not possible to set a tensor split.\n");
 #endif // GGML_USE_CUBLAS

--- a/examples/falcon_common.cpp
+++ b/examples/falcon_common.cpp
@@ -305,6 +305,7 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
             }
 #ifdef GGML_USE_CUBLAS
             params.main_gpu = std::stoi(argv[i]);
+            ggml_cuda_set_main_device(params.main_gpu);
 #else
       fprintf(stderr, "warning: falcon.cpp was compiled without cuBLAS. It is not possible to set a main GPU.\n");
 #endif

--- a/examples/falcon_common.cpp
+++ b/examples/falcon_common.cpp
@@ -322,13 +322,20 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
             std::sregex_token_iterator it{arg_next.begin(), arg_next.end(), regex, -1};
             std::vector<std::string> split_arg{it, {}};
             GGML_ASSERT(split_arg.size() <= LLAMA_MAX_DEVICES);
-
+            bool all_zero = true;
             for (size_t i = 0; i < LLAMA_MAX_DEVICES; ++i) {
                 if (i < split_arg.size()) {
                     params.tensor_split[i] = std::stof(split_arg[i]);
+                    if (params.tensor_split[i] != 0.0f) {
+                        all_zero = false;
+                    }
                 } else {
                     params.tensor_split[i] = 0.0f;
                 }
+            }
+            if (all_zero) {
+                fprintf(stderr, "Error: all tensor split proportions are zero\n");
+                exit(1);
             }
             ggml_cuda_set_tensor_split_prepare(params.tensor_split,split_arg.size());
 #else
@@ -417,6 +424,21 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
     if (escape_prompt) {
         process_escapes(params.prompt);
     }
+
+
+      bool all_zero = true;
+        for (size_t i = 0; i < LLAMA_MAX_DEVICES; ++i) {
+            if (params.tensor_split[i] != 0.0f) {
+                all_zero = false;
+                break;
+            }
+        }
+        if (!all_zero) {
+            if (params.tensor_split[params.main_gpu] == 0.0f) {
+                fprintf(stderr, "Error: main GPU cannot have a tensor split proportion of zero.\n");
+                exit(1);
+            }
+        }
 
     return true;
 }

--- a/examples/falcon_common.cpp
+++ b/examples/falcon_common.cpp
@@ -306,7 +306,7 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
 #ifdef GGML_USE_CUBLAS
             params.main_gpu = std::stoi(argv[i]);
 #else
-      fprintf(stderr, "warning: llama.cpp was compiled without cuBLAS. It is not possible to set a main GPU.\n");
+      fprintf(stderr, "warning: falcon.cpp was compiled without cuBLAS. It is not possible to set a main GPU.\n");
 #endif
         } else if (arg == "--tensor-split" || arg == "-ts") {
             if (++i >= argc) {
@@ -330,7 +330,7 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
                 }
             }
 #else
-      fprintf(stderr, "warning: llama.cpp was compiled without cuBLAS. It is not possible to set a tensor split.\n");
+      fprintf(stderr, "warning: falcon.cpp was compiled without cuBLAS. It is not possible to set a tensor split.\n");
 #endif // GGML_USE_CUBLAS
         } else if (arg == "--no-mmap") {
             params.use_mmap = false;

--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -1581,7 +1581,7 @@ void ggml_cuda_print_gpu_status(const GPUStatus *status) {
     const char *divider = "+------------------------------------+------------+-----------+-----------+-----------+-----------+";
     printf("\nCUDA Device Summary - %d devices found\n", status->num_devices);
     printf("%s\n", divider);
-    printf("| %-34s | %10s | %9s | %9s | %9s | %9s |\n", "Device", "VRAM Total", "VRAM Free", "VRAM Used","Split at %", "Device ID");
+    printf("| %-34s | %10s | %9s | %9s | %9s | %9s |\n", "Device", "VRAM Total", "VRAM Free", "VRAM Used","Split at ", "Device ID");
     printf("%s\n", divider);
 
     for (int i = 0; i < status->num_devices; ++i) {

--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -1530,6 +1530,7 @@ void ggml_cuda_update_gpu_status(int device_id) {
                 CUDA_CHECK(cudaGetDeviceProperties(&g_system_gpu_status.device_props[id], id));
             }
         }
+        g_system_gpu_status.total_vram = 0;
         g_system_gpu_status.total_free_vram = 0;
         for (int id = 0; id < g_system_gpu_status.num_devices; ++id) {
             CUDA_CHECK(cudaSetDevice(id));

--- a/ggml-cuda.h
+++ b/ggml-cuda.h
@@ -1,6 +1,7 @@
 #pragma once
-
+#include <cuda_runtime.h>
 #include "ggml.h"
+
 
 #ifdef  __cplusplus
 extern "C" {
@@ -11,8 +12,21 @@ extern "C" {
 struct ggml_tensor_extra_gpu {
     void * data_device[GGML_CUDA_MAX_DEVICES]; // 1 pointer for each device for split tensors
 };
+typedef struct {
+    int num_devices;
+    int main_device_id;
+    size_t total_vram;
+    size_t total_free_vram;
+    struct cudaDeviceProp device_props[GGML_CUDA_MAX_DEVICES];
+    size_t device_vram_free[GGML_CUDA_MAX_DEVICES];
+    size_t device_vram_total[GGML_CUDA_MAX_DEVICES];
+} GPUStatus;
+const GPUStatus* ggml_cuda_get_system_gpu_status();
 
 void   ggml_init_cublas(void);
+void   ggml_cuda_update_gpu_status(int device_id);
+void   ggml_cuda_print_gpu_status(const GPUStatus *status);
+void   ggml_cuda_set_tensor_split_prepare(const float * tensor_split, int num_devices);
 void   ggml_cuda_set_tensor_split(const float * tensor_split);
 
 void   ggml_cuda_mul(const struct ggml_tensor * src0, const struct ggml_tensor * src1, struct ggml_tensor * dst);

--- a/ggml.c
+++ b/ggml.c
@@ -14615,7 +14615,7 @@ static void ggml_compute_forward(struct ggml_compute_params * params, struct ggm
         return;
     }
     if (tensor->src0->backend != GGML_BACKEND_CPU) 
-    printf("%s src0->backend != GGML_BACKEND_CPU (%s; %s)\n", ggml_op_name  (tensor->op),tensor->name,tensor->src0->src0->name);
+        printf("%s src0->backend != GGML_BACKEND_CPU (%s, %s)\n", ggml_op_name(tensor->op),tensor->name, tensor->src0->name);
     GGML_ASSERT(tensor->src0->backend == GGML_BACKEND_CPU);
     GGML_ASSERT(tensor->src1 == NULL || tensor->src1->backend == GGML_BACKEND_CPU);
 #endif // GGML_USE_CUBLAS

--- a/libfalcon.cpp
+++ b/libfalcon.cpp
@@ -1269,7 +1269,8 @@ static void falcon_model_load_internal(
         if (n_gpu_layers == 0) offload_output = false;
 
         if (offload_output) { // NOLINT
-            backend_norm = LLAMA_BACKEND_OFFLOAD; // not used yet but tiny tensor
+            // backend_norm = LLAMA_BACKEND_OFFLOAD; // this requires REPEAT on GPU (in f7b)
+            backend_norm = GGML_BACKEND_CPU; 
             backend_output = LLAMA_BACKEND_OFFLOAD_SPLIT;
         } else {
             backend_norm = GGML_BACKEND_CPU;

--- a/libfalcon.cpp
+++ b/libfalcon.cpp
@@ -1397,6 +1397,7 @@ static void falcon_model_load_internal(
         model.tensors_by_name.emplace_back(lt.name, lt.ggml_tensor);
     }
 
+/*  moved into common so that it is set from begin on and can be visualized before evaluation starts
     (void) tensor_split;
 #if defined(GGML_USE_CUBLAS)
     {
@@ -1404,6 +1405,7 @@ static void falcon_model_load_internal(
         ggml_cuda_set_tensor_split(tensor_split);
     }
 #endif
+*/
 
     ml->load_all_data(progress_callback, progress_callback_user_data, use_mlock ? &lctx.model.mlock_mmap : NULL);
 

--- a/libfalcon.cpp
+++ b/libfalcon.cpp
@@ -768,7 +768,7 @@ struct llama_model_loader {
         }
     }
 
-    void load_all_data(llama_progress_callback progress_callback, void *  progress_callback_user_data, llama_mlock * lmlock) {
+    void load_all_data(falcon_progress_callback progress_callback, void *  progress_callback_user_data, llama_mlock * lmlock) {
         size_t data_size = 0;
         size_t prefetch_size = 0;
         size_t lock_size = 0;
@@ -789,7 +789,15 @@ struct llama_model_loader {
         size_t done_size = 0;
         for (falcon_load_tensor & lt : tensors_map.tensors) {
             if (progress_callback) {
-                progress_callback((float) done_size / data_size, progress_callback_user_data);
+                char *status="";
+                if (lt.ggml_tensor->backend == GGML_BACKEND_CPU) 
+                    status = "Loading tensor (CPU)";
+                else if (lt.ggml_tensor->backend == GGML_BACKEND_GPU)
+                    status = "Loading tensor (GPU-Main)";
+                else if (lt.ggml_tensor->backend == GGML_BACKEND_GPU_SPLIT)
+                    status = "Loading tensor (GPU-Split)";
+
+                progress_callback((float) done_size / data_size, progress_callback_user_data,status);
             }
             LLAMA_ASSERT(lt.ggml_tensor); // unused tensors should have been caught by load_data already
             lt.data = (uint8_t *) lt.ggml_tensor->data;
@@ -1084,7 +1092,7 @@ static void falcon_model_load_internal(
         bool use_mmap,
         bool use_mlock,
         bool vocab_only,
-        llama_progress_callback progress_callback,
+        falcon_progress_callback progress_callback,
         void * progress_callback_user_data) {
 
     lctx.t_start_us = ggml_time_us(); 
@@ -1253,9 +1261,12 @@ if (n_gpu_layers > 0)
        
         ggml_backend backend_norm;
         ggml_backend backend_output;
-        // disabled norm/output offloading until further tests, causes silent crash at the moment
-        if (n_gpu_layers > int(n_layer) && false) { // NOLINT
-            backend_norm = LLAMA_BACKEND_OFFLOAD;
+        // output layer offloading is on by default now, it's one of the biggest CPU consumers
+        bool offload_output = true;
+        if (n_gpu_layers == 0) offload_output = false;
+
+        if (offload_output) { // NOLINT
+            backend_norm = LLAMA_BACKEND_OFFLOAD; // not used yet but tiny tensor
             backend_output = LLAMA_BACKEND_OFFLOAD_SPLIT;
         } else {
             backend_norm = GGML_BACKEND_CPU;
@@ -1279,6 +1290,7 @@ if (n_gpu_layers > 0)
         {
             vram_weights += ggml_nbytes(model.lm_head);
             vram_free -= ggml_nbytes(model.lm_head);
+            fprintf(stderr, "%s: Offloading Output head tensor (%ld MB)\n", __func__, ggml_nbytes(model.lm_head)/MB);
         }
 
         int i_gpu_start = n_layer - n_gpu_layers;
@@ -1370,9 +1382,6 @@ if (n_gpu_layers > 0)
 
         fprintf(stderr, "%s: offloading %d of %d layers to GPU, weights offloaded %7.2f MB\n",
                 __func__, n_gpu, hparams.n_layer, vram_weights / 1024.0 / 1024.0);
-        if (n_gpu_layers > (int) hparams.n_layer) {
-            fprintf(stderr, "%s: offloading output layer to GPU\n", __func__);
-        }
         fprintf(stderr, "%s: estimated VRAM usage: %zu MB\n",
                 __func__, (vram_weights + vram_scratch + vram_overhead + MB - 1) / MB); // round up
 #else
@@ -1388,6 +1397,7 @@ if (n_gpu_layers > 0)
     (void) tensor_split;
 #if defined(GGML_USE_CUBLAS)
     {
+        // optional tensor split by custom parameters if defined
         ggml_cuda_set_tensor_split(tensor_split);
     }
 #endif
@@ -1395,7 +1405,7 @@ if (n_gpu_layers > 0)
     ml->load_all_data(progress_callback, progress_callback_user_data, use_mlock ? &lctx.model.mlock_mmap : NULL);
 
     if (progress_callback) {
-        progress_callback(1.0f, progress_callback_user_data);
+        progress_callback(1.0f, progress_callback_user_data,"Tensors populated");
     }
 
     #if defined(GGML_USE_CUBLAS)
@@ -1426,7 +1436,7 @@ static bool falcon_model_load(
         bool use_mmap,
         bool use_mlock,
         bool vocab_only,
-        llama_progress_callback progress_callback,
+        falcon_progress_callback progress_callback,
         void *progress_callback_user_data) {
     try {
         falcon_model_load_internal(fname, lctx, n_ctx, n_batch, n_gpu_layers, main_gpu, tensor_split, memory_type,
@@ -1521,7 +1531,7 @@ static bool falcon_eval_internal(
     offload_func_t offload_func_kqv = llama_nop;
 
 #ifdef GGML_USE_CUBLAS
-        // todo: use either a flag in model/params or a backend test to determine if norm/output are on GPU
+        // todo: instead of n_layer use either a flag in model/params or a backend test to determine if norm/output are on GPU
         if (n_gpu_layers > n_layer) {
             offload_func_nr = ggml_cuda_assign_buffers;
         }
@@ -1535,7 +1545,7 @@ static bool falcon_eval_internal(
         offload_func_t offload_func = llama_nop;
 
 #ifdef GGML_USE_CUBLAS
-        if (il >= i_gpu_start && il < i_gpu_last) {
+        if (il >= i_gpu_start && il <= i_gpu_last) {
             offload_func = ggml_cuda_assign_buffers; // sets the output backend to GPU
         }
 #endif // GGML_USE_CUBLAS
@@ -1831,7 +1841,8 @@ static bool falcon_eval_internal(
             if ((first && debug_timings <=2) || debug_timings > 2)
             {
                 first = false;
-                ggml_graph_print_impl(&gf,true,false,GGML_OP_NONE); // GGML_OP_MUL_MAT
+                // ggml_graph_print_impl(&gf,true,false,GGML_OP_MUL_MAT); // GGML_OP_MUL_MAT / GGML_OP_NONE
+                ggml_graph_print_impl(&gf,true,false,GGML_OP_NONE); // GGML_OP_MUL_MAT / GGML_OP_NONE
             }
         }
         // requires GGML_PERF to be defined for actual timing information
@@ -2751,15 +2762,37 @@ struct falcon_context * falcon_init_from_file(
 
     unsigned cur_percentage = 0;
     if (params.progress_callback == NULL) {
-        params.progress_callback_user_data = &cur_percentage;
-        params.progress_callback = [](float progress, void * ctx) {
-            unsigned * cur_percentage_p = (unsigned *) ctx;
+        params.progress_callback_user_data = &cur_percentage; // not sure why this is so complicated ? I left it for now
+        params.progress_callback = [](float progress, void * ctx, char *status) {
             unsigned percentage = (unsigned) (100 * progress);
-            while (percentage > *cur_percentage_p) {
+            unsigned * cur_percentage_p = (unsigned *) ctx;
+            static const int bar_width = 50;
+            bool completed = false;
+            if (percentage >= 100) {
+                completed = true;
+                if (!strlen(status))
+                status = "Completed";
+            }
+
+            if (percentage > *cur_percentage_p) {
                 *cur_percentage_p = percentage;
-                fprintf(stderr, ".");
+                fprintf(stderr, "\r["); // using '\r' to overwrite the current line
+                int progress_position = percentage * bar_width / 100;
+                for (int i = 0; i < bar_width; ++i) {
+                    if (i < progress_position) {
+                        fprintf(stderr, "=");
+                    } else if (i == progress_position) {
+                        fprintf(stderr, ">");
+                    } else {
+                        fprintf(stderr, "-");
+                    }
+                }
+
+                fprintf(stderr, "] %3u%%  %-30s", percentage, status);
+
+                
                 fflush(stderr);
-                if (percentage >= 100) {
+                if (completed) {
                     fprintf(stderr, "\n");
                 }
             }

--- a/libfalcon.h
+++ b/libfalcon.h
@@ -69,7 +69,7 @@ extern "C" {
         bool sorted;
     } llama_token_data_array;
 
-    typedef void (*llama_progress_callback)(float progress, void *ctx);
+    typedef void (*falcon_progress_callback)(float progress, void *ctx, char *status);
 
     struct falcon_context_params {
         int n_ctx;                             // text context
@@ -89,7 +89,7 @@ extern "C" {
         bool embedding;  // embedding mode only
 
         // called with a progress value between 0 and 1, pass NULL to disable
-        llama_progress_callback progress_callback;
+        falcon_progress_callback progress_callback;
         // context pointer passed to the progress callback
         void * progress_callback_user_data;
     };


### PR DESCRIPTION
1) Multi GPU support works again
- splitting, disabling devices and setting main device
2) Created a well features GPU status message replacing the log lines from before
- required move some global variables into the struct, still a bit cleanup open
3) Internal work on ggml-cuda.cu to support a global system status struct
- accessible as readonly data from outside, so eval() or loader() can access vram information
4) Moves the tensor_split and main_gpu settings from evaluation() and loader() into falcon_common
- this means the main device and the tensor split proportions can be set and seen before loader() or eval() started


Here is example run of 38GB  Falcon 40B in q6_k quantization at almost 13 tk/sec:
```
 .\build\bin\Release\falcon_main.exe -t 7 -m Q:\models\falcon-40b-instruct\q6_k -b 1 -n 32 -p "To construct a successful website we need to focus on the 10 short steps:" --debug-timings 0 -s 1 -mg 0  -t 7  -ngl 60 -ts 1.3,1
WARNING: when using cuBLAS generation results are NOT guaranteed to be reproducible.
main: build = 772 (fdd53b4)
main: seed  = 1

CUDA Device Summary - 2 devices found
+------------------------------------+------------+-----------+-----------+-----------+-----------+
| Device                             | VRAM Total | VRAM Free | VRAM Used | Split at  | Device ID |
+------------------------------------+------------+-----------+-----------+-----------+-----------+
| NVIDIA GeForce RTX 4090            |   24563 MB |  23006 MB |   1557 MB |      0.0% |  0 (Main) |
+------------------------------------+------------+-----------+-----------+-----------+-----------+
| NVIDIA GeForce RTX 3090            |   24575 MB |  23318 MB |   1257 MB |     56.5% |  1        |
+------------------------------------+------------+-----------+-----------+-----------+-----------+
Total VRAM: 47.99 GB, Total available VRAM: 45.24 GB
--------------------
falcon.cpp: loading model from Q:\models\falcon-40b-instruct\q6_k
falcon.cpp: file version 4
falcon_model_load_internal: format     = ggjt v3 (latest)
falcon_model_load_internal: n_vocab    = 65024
falcon_model_load_internal: n_ctx      = 512
falcon_model_load_internal: n_embd     = 8192
falcon_model_load_internal: n_head     = 128
falcon_model_load_internal: n_head_kv     = 8
falcon_model_load_internal: n_layer    = 60
falcon_model_load_internal: n_falcon_type      = 40
falcon_model_load_internal: ftype      = 18 (mostly Q6_K)
falcon_model_load_internal: n_ff       = 32768
falcon_model_load_internal: n_parts    = 1
falcon_model_load_internal: model size = 40B
falcon_model_load_internal: ggml ctx size =    0.00 MB (mmap size = 32734.00 MB)
falcon_model_load_internal: using CUDA for GPU acceleration
falcon_model_load_internal: VRAM free: 46324.00 MB  of 49139.00 MB (in use: 2815.00 MB)
falcon_model_load_internal: allocating batch_size x 1 MB = 0 MB VRAM for the scratch buffer
falcon_model_load_internal: Offloading Output head tensor (416 MB)
falcon_model_load_internal: mem required  = 4008.45 MB (+  120.00 MB per state)
falcon_model_load_internal: offloading 60 of 60 layers to GPU, weights offloaded 32310.47 MB
falcon_model_load_internal: estimated VRAM usage: 33561 MB
[==================================================] 100%  Tensors populated
falcon_model_load_internal: VRAM free: 11640.00 MB  of 49139.00 MB (used: 37498.00 MB)
falcon_init_from_file: kv self size  =  120.00 MB

system_info: n_threads = 7 / 32 | AVX = 1 | AVX2 = 1 | AVX512 = 0 | AVX512_VBMI = 0 | AVX512_VNNI = 0 | FMA = 1 | NEON = 0 | ARM_FMA = 0 | F16C = 1 | FP16_VA = 0 | WASM_SIMD = 0 | BLAS = 1 | SSE3 = 1 | VSX = 0 |
sampling: repeat_last_n = 64, repeat_penalty = 1.100000, presence_penalty = 0.000000, frequency_penalty = 0.000000, top_k = 40, tfs_z = 1.000000, top_p = 0.950000, typical_p = 1.000000, temp = 0.800000, mirostat = 0, mirostat_lr = 0.100000, mirostat_ent = 5.000000
generate: n_ctx = 512, n_batch = 1, n_predict = 32, n_keep = 0


To construct a successful website we need to focus on the 10 short steps:
- Define The Purpose Of Your Website: Why do you want to build your website? Are you trying to sell products or services? Do you want to inform
falcon_print_timings:        load time = 12857.69 ms
falcon_print_timings:      sample time =     7.37 ms /    32 runs   (    0.23 ms per token)
falcon_print_timings: prompt eval time =     0.00 ms /     1 tokens (    0.00 ms per token)
falcon_print_timings:        eval time =  3721.17 ms /    47 runs   (   79.17 ms per token)
falcon_print_timings:       total time =  3733.78 ms
```