### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,7 +251,7 @@ ggml.o: ggml.c ggml.h ggml-cuda.h
 llama.o: llama.cpp ggml.h ggml-cuda.h llama.h llama-util.h
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
-cmpnct_unicode.o cmpnct_unicode.cpp cmpnct_unicode.h
+cmpnct_unicode.o: cmpnct_unicode.cpp cmpnct_unicode.h
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 libfalcon.o: libfalcon.cpp ggml.h ggml-cuda.h libfalcon.h llama-util.h cmpnct_unicode.h

--- a/Makefile
+++ b/Makefile
@@ -285,17 +285,17 @@ simple: examples/simple/simple.cpp                            build-info.h ggml.
 quantize: examples/quantize/quantize.cpp                      build-info.h ggml.o llama.o $(OBJS)
 	$(CXX) $(CXXFLAGS) $(filter-out %.h,$^) -o $@ $(LDFLAGS)
 
-falcon_main: examples/falcon/falcon_main.cpp                                  build-info.h ggml.o libfalcon.o libfalcon.o falcon_common.o $(OBJS)
+falcon_main: examples/falcon/falcon_main.cpp                                  build-info.h ggml.o libfalcon.o libfalcon.o cmpnct_unicode.o falcon_common.o $(OBJS)
 	$(CXX) $(CXXFLAGS) $(filter-out %.h,$^) -o $@ $(LDFLAGS)
 	@echo
 	@echo '====  Run ./falcon_main -h for help.  ===='
 	@echo 'Read the readme file for important parameters and usage'
 	@echo
 
-falcon_quantize: examples/falcon_quantize/quantize.cpp                      build-info.h ggml.o libfalcon.o libfalcon.o $(OBJS)
+falcon_quantize: examples/falcon_quantize/quantize.cpp                      build-info.h ggml.o libfalcon.o libfalcon.o cmpnct_unicode.o  $(OBJS)
 	$(CXX) $(CXXFLAGS) $(filter-out %.h,$^) -o $@ $(LDFLAGS)
 
-falcon_perplexity: examples/falcon_perplexity/falcon_perplexity.cpp                build-info.h ggml.o libfalcon.o libfalcon.o falcon_common.o $(OBJS)
+falcon_perplexity: examples/falcon_perplexity/falcon_perplexity.cpp                build-info.h ggml.o libfalcon.o libfalcon.o falcon_common.o cmpnct_unicode.o $(OBJS)
 	$(CXX) $(CXXFLAGS) $(filter-out %.h,$^) -o $@ $(LDFLAGS)
 
 


### PR DESCRIPTION
Fixes two errors:

```bash
$ make falcon_main falcon_quantize falcon_perplexity
I ggllm.cpp build info:
I UNAME_S:  Linux
I UNAME_P:  x86_64
I UNAME_M:  x86_64
I CFLAGS:   -I.              -O3 -std=c11   -fPIC -DNDEBUG -DGGML_PERF=1 -Wall -Wextra -Wpedantic -Wcast-qual -Wdouble-promotion -Wshadow -Wstrict-prototypes -Wpointer-arith -pthread -march=native -mtune=native -DGGML_USE_K_QUANTS -DGGML_USE_CUBLAS -I/usr/local/cuda/include -I/opt/cuda/include -I/targets/x86_64-linux/include
I CXXFLAGS: -I. -I./examples -O3 -std=c++11 -fPIC -DNDEBUG -DGGML_PERF=1 -Wall -Wextra -Wpedantic -Wcast-qual -Wno-unused-function -Wno-multichar -pthread -march=native -mtune=native -DGGML_USE_K_QUANTS -DGGML_USE_CUBLAS -I/usr/local/cuda/include -I/opt/cuda/include -I/targets/x86_64-linux/include
I LDFLAGS:   -lcublas -lculibos -lcudart -lcublasLt -lpthread -ldl -lrt -L/usr/local/cuda/lib64 -L/opt/cuda/lib64 -L/targets/x86_64-linux/lib
I CC:       cc (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0
I CXX:      g++ (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0

Makefile:254: *** missing separator.  Stop.
```

```
g++ -I. -I./examples -O3 -std=c++11 -fPIC -DNDEBUG -DGGML_PERF=1 -Wall -Wextra -Wpedantic -Wcast-qual -Wno-unused-function -Wno-multichar -pthread -march=native -mtune=native -DGGML_USE_K_QUANTS
 -DGGML_USE_CUBLAS -I/usr/local/cuda/include -I/opt/cuda/include -I/targets/x86_64-linux/include examples/falcon_perplexity/falcon_perplexity.cpp ggml.o libfalcon.o falcon_common.o k_quants.o gg
ml-cuda.o -o falcon_perplexity  -lcublas -lculibos -lcudart -lcublasLt -lpthread -ldl -lrt -L/usr/local/cuda/lib64 -L/opt/cuda/lib64 -L/targets/x86_64-linux/lib
/usr/bin/ld: libfalcon.o: in function `falcon_tokenizer::bpe_gpt2_preprocess(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':                            
libfalcon.cpp:(.text._ZN16falcon_tokenizer19bpe_gpt2_preprocessERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE[_ZN16falcon_tokenizer19bpe_gpt2_preprocessERKNSt7__cxx1112basic_stringIcSt1
1char_traitsIcESaIcEEE]+0x116): undefined reference to `CNCTUnicode::split_utf8_enhanced(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'              
<--SNIP-->
/usr/bin/ld: libfalcon.cpp:(.text._ZN16falcon_tokenizer19bpe_gpt2_preprocessERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE[_ZN16falcon_tokenizer19bpe_gpt2_preprocessERKNSt7__cxx1112basi
c_stringIcSt11char_traitsIcESaIcEEE]+0x7e9): undefined reference to `CNCTString::operator==(char) const' 
undefined reference to `CNCTUnicode::split_utf8(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
collect2: error: ld returned 1 exit status
```