### PR TITLE
16k+ context upgrade - Long-range Falcon

### DIFF
--- a/examples/falcon/falcon_main.cpp
+++ b/examples/falcon/falcon_main.cpp
@@ -108,10 +108,25 @@ int main(int argc, char ** argv) {
     }
 
     if (params.n_ctx > 2048) {
-        fprintf(stderr, "%s: warning: model does not support context sizes greater than 2048 tokens (%d specified);"
-                "expect poor results\n", __func__, params.n_ctx);
+        if (params.sampling_not_default)
+        {
+            // a slightly lower temperature can help offset perplexity increases - those numbers need some tuning
+            if (params.n_ctx >= 4096) {
+                fprintf(stderr, "%s: info: context size is large (%d), reducing default temperature to 0.7.\n", __func__, params.n_ctx);
+                params.temp = 0.7f;
+            } else
+            if (params.n_ctx >= 8192) {
+                fprintf(stderr, "%s: info: context size is very large (%d), reducing default temperature to 0.6.\n", __func__, params.n_ctx);
+                params.temp = 0.6f;
+            } else
+            if (params.n_ctx >= 16384) {
+                fprintf(stderr, "%s: info: context size is extremely large (%d), reducing default temperature to 0.5.\n", __func__, params.n_ctx);
+                params.temp = 0.5f;
+            }
+
+        }
     } else if (params.n_ctx < 8) {
-        fprintf(stderr, "%s: warning: minimum context size is 8, using minimum size.\n", __func__);
+        fprintf(stderr, "%s: warning: minimum context size is 8.\n", __func__);
         params.n_ctx = 8;
     }
 
@@ -175,12 +190,22 @@ int main(int argc, char ** argv) {
         // falcon_context_set_buffers(ctx, params.n_batch, params.n_ctx);
         {
             const std::vector<falcon_token> tmp((int)params.n_batch, falcon_token_bos());
-            falcon_eval(ctx, tmp.data(), (int)tmp.size(), 0, params.n_threads,params.debug_timings);
+            falcon_evaluation_config configuration;
+                configuration.n_past = 0;
+                configuration.debug_timings = params.debug_timings;
+                configuration.n_threads = params.n_threads;
+                configuration.n_tokens = (int)tmp.size();
+            falcon_eval(ctx, tmp.data(), configuration);
         }
 
         {
             const std::vector<falcon_token> tmp = { 0, };
-            falcon_eval(ctx, tmp.data(), (int)tmp.size(), params.n_predict - 1, params.n_threads,params.debug_timings);
+            falcon_evaluation_config configuration;
+                configuration.n_past = params.n_predict - 1;
+                configuration.debug_timings = params.debug_timings;
+                configuration.n_threads = params.n_threads;
+                configuration.n_tokens = (int)tmp.size();
+            falcon_eval(ctx, tmp.data(), configuration);
         }
 
         falcon_print_timings(ctx);
@@ -624,7 +649,12 @@ fprintf(stderr, "+------------+-------+-------+-------+-------+---------------+-
     if(n_matching_session_tokens <= 0)
     {
         const std::vector<falcon_token> tmp = { falcon_token_bos(), };
-        falcon_eval(ctx, tmp.data(), (int)tmp.size(), 0, params.n_threads,0);
+        falcon_evaluation_config configuration;
+                configuration.n_past = 0;
+                configuration.debug_timings = 0;
+                configuration.n_threads = params.n_threads;
+                configuration.n_tokens = (int)tmp.size();
+        falcon_eval(ctx, tmp.data(), configuration);
         llama_reset_timings(ctx);
     }
 
@@ -783,7 +813,14 @@ fprintf(stderr, "+------------+-------+-------+-------+-------+---------------+-
                 }
                 int debug_timings = params.debug_timings;
                 if (n_remain == 1 && debug_timings == 2) debug_timings = 3; // we have no access to the last information in eval()
-                if (falcon_eval(ctx, &embd[i], n_eval, n_past, params.n_threads,debug_timings)) {
+                falcon_evaluation_config configuration;
+                configuration.n_past = n_past;
+                configuration.debug_timings = debug_timings;
+                configuration.n_threads = params.n_threads;
+                configuration.n_tokens = n_eval;
+                if (!params.interactive && params.n_predict > 0)
+                    configuration.n_max_real_ctx = std::min((int)n_ctx, (int)(prompt_size+params.n_predict));
+                if (falcon_eval(ctx, &embd[i], configuration)) {
                     fprintf(stderr, "%s : failed to eval\n", __func__);
                     return 1;
                 }

--- a/examples/falcon_common.cpp
+++ b/examples/falcon_common.cpp
@@ -203,6 +203,7 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
                 break;
             }
             params.top_k = std::stoi(argv[i]);
+            params.sampling_not_default=true;
         } else if (arg == "-c" || arg == "--ctx-size") {
             if (++i >= argc) {
                 invalid_param = true;
@@ -217,12 +218,14 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
                 break;
             }
             params.top_p = std::stof(argv[i]);
+            params.sampling_not_default=true;
         } else if (arg == "--temp") {
             if (++i >= argc) {
                 invalid_param = true;
                 break;
             }
             params.temp = std::stof(argv[i]);
+            params.sampling_not_default=true;
         } else if (arg == "--tfs") {
             if (++i >= argc) {
                 invalid_param = true;
@@ -235,6 +238,7 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
                 break;
             }
             params.typical_p = std::stof(argv[i]);
+            params.sampling_not_default=true;
         } else if (arg == "--repeat-last-n") {
             if (++i >= argc) {
                 invalid_param = true;
@@ -265,6 +269,7 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
                 break;
             }
             params.mirostat = std::stoi(argv[i]);
+            params.sampling_not_default=true;
         } else if (arg == "--mirostat-lr") {
             if (++i >= argc) {
                 invalid_param = true;

--- a/examples/falcon_common.h
+++ b/examples/falcon_common.h
@@ -26,7 +26,7 @@ struct gpt_params {
     int32_t seed                           = -1;   // RNG seed
     int32_t n_threads                      = 1;
     int32_t n_predict                      = -1;   // new tokens to predict
-    int32_t n_ctx                          = 512;  // context size
+    int32_t n_ctx                          = 2048;  // context size
     int32_t n_batch                        = 1;  // batch size for prompt processing (must be >=32 to use BLAS)
     int32_t n_keep                         = 0;    // number of tokens to keep from initial prompt
     int32_t n_gpu_layers                   = 200;  // number of layers to store in VRAM
@@ -90,6 +90,7 @@ struct gpt_params {
     bool mem_test          = false; // compute maximum memory usage
     bool export_cgraph     = false; // export the computation graph
     bool verbose_prompt    = false; // print prompt tokens before generation
+    bool sampling_not_default = false; // readonly, true if any sampling change is requested
     int debug_timings      = 0;     // print timings (required for GGML_PERF=1)
 };
 

--- a/examples/falcon_perplexity/falcon_perplexity.cpp
+++ b/examples/falcon_perplexity/falcon_perplexity.cpp
@@ -62,8 +62,12 @@ void perplexity(falcon_context * ctx, const gpt_params & params) {
             if (j == 0) {
                 // tokens[batch_start] = falcon_token_bos();
             }
-
-            if (falcon_eval(ctx, tokens.data() + batch_start, batch_size, j * n_batch, params.n_threads, params.debug_timings)) {
+            falcon_evaluation_config configuration;
+                configuration.n_past = j * n_batch;
+                configuration.n_tokens = batch_size;
+                configuration.debug_timings = params.debug_timings;
+                configuration.n_threads = params.n_threads;
+            if (falcon_eval(ctx, tokens.data() + batch_start, configuration)) {
                 fprintf(stderr, "%s : failed to eval\n", __func__);
                 return;
             }

--- a/ggml.h
+++ b/ggml.h
@@ -1560,8 +1560,11 @@ extern "C" {
     //
     // custom optional parameters in meta struct
     //
-    #define GGML_CUSTOM_F_ROPE_ANG_SCALE 0 // theta pre scale
-    #define GGML_CUSTOM_I_ROPE_ANG_FREQ 0 // frequency base for rotation in hz
+    // -- ROPE --
+    #define GGML_CUSTOM_F_ROPE_ANG_SCALE 0 // theta pre scale (basically scales n_past linearly)
+    #define GGML_CUSTOM_F_ROPE_NTK_ALPHA 1 // 4/8; theta base freq alpha scale (NTK fourier space) - best in combination with DYNAMIC_MODE = 1
+    #define GGML_CUSTOM_I_ROPE_ANG_FREQ 0 // base freq (GPT default is 10000)
+    #define GGML_CUSTOM_I_ROPE_DYNAMIC_MODE 1 // 1 = dynamic scaling based on given n_ctx and optional NTK_ALPHA using the research of u/emozilla and u/bloc97 of adaptive fourier space scaling of the rotation
     // #define GGML_CUSTOM_I_ROPE_ANG_PHASE_N 1 // phase offset for rotation in number of tokens from default
 
 

--- a/libfalcon.h
+++ b/libfalcon.h
@@ -76,6 +76,20 @@ extern "C" {
 
     typedef void (*falcon_progress_callback)(float progress, void *ctx, const char *status);
 
+    struct falcon_evaluation_config {
+        // mandatory configuration
+        int n_tokens = 1;       // number of tokens to process
+        int n_past = 0;         // number of tokens in kv cache past
+        int n_threads = 1;      // number of threads available
+
+        // optional
+        const char *cgraph_fname = nullptr; // path to the cgraph export file
+        int n_max_real_ctx = 0; // the actual max achievable context given all parameters (-c, -n, -enc, -sys)
+
+        // debug related
+        int debug_timings = 0;  // 0 (none), 1(first token), 2(first,last), 3(every token)
+    };
+
     struct falcon_context_params {
         int n_ctx;                             // text context
         int n_batch;                           // prompt processing batch size
@@ -206,10 +220,7 @@ extern "C" {
     LLAMA_API int falcon_eval(
             struct falcon_context * ctx,
                const falcon_token * tokens,
-                             int   n_tokens,
-                             int   n_past,
-                             int   n_threads, 
-                             int debug_timings);
+                             falcon_evaluation_config & configuration);
 
     // Export a static computation graph for context of 511 and batch size of 1
     // NOTE: since this functionality is mostly for debugging and demonstration purposes, we hardcode these


### PR DESCRIPTION
Default context is now 2048
The embedding rotation has been adapted to react to context and expected generation Uses "NTK" fourier aware scaling of the rotation space.

7B and 40B have been tested to work well up to a context of 8k Tests at > 8k are incoming once performance at these sizes works better

RAM requirements for K/V caches:
Falcon 7B at 8k context : ~2 GB RAM
Falcon 40B at 8k context : ~5.5 GB RAM

In addition falcon_eval() now uses a configuration struct instead of passing many parameters through multiple abstraction layers. This makes it much easier to pass new features from main into libfalcon