### PR TITLE
refactor gpt_params_parse, add validate_params function

### DIFF
--- a/examples/falcon_common.cpp
+++ b/examples/falcon_common.cpp
@@ -505,7 +505,7 @@ bool gpt_params_parse(int argc, char ** argv, gpt_params & params) {
         return true;
     } catch (const std::exception& e) {
         // Handle exceptions thrown by validate_params or other parts of the function
-        fprintf(stderr, "\nError: %s\n\n", e.what());
+        fprintf(stderr, "\nError: Parameter '%s':\n  %s\n\n", arg.c_str(), e.what());
         fprintf(stderr, "For detailed help, use: -h or --help\n");
         return false; // Return false to indicate an error in parameter parsing
     }


### PR DESCRIPTION
The parsing of the parameters is broken.
Basically, parameters were only parsed correctly to arguments if it was the last argument of the command line. For most parameter errors in the middle of the command line, the program terminates without any error message.

A separate validate_params function fixes these problems.
Originally there was the thought to provide the validate function with checks for numeric or string values, but after switching the function to error handling with try/catch it turns out that the `std::stoi`, `std::stof` functions then provide these messages for free.

Since the help text is very long, it is not very helpful to display the entire help text for each error - on the contrary, this hides the actual error message, because you have to scroll back page by page to be able to read it.
In case of an error, an error message is now displayed that is much more meaningful than before, as well as a reference to the help.
