### PR TITLE
Update openbuddy's vocab size

### DIFF
--- a/libfalcon.cpp
+++ b/libfalcon.cpp
@@ -1497,7 +1497,8 @@ t_finetune_type falcon_detect_finetune(falcon_context * ctx, std::string model_p
             return FINETUNE_OPENASSISTANT;
         }
     }
-    if (ctx->vocab.id_to_token.size() == 70144)
+    auto vocabSize = ctx->vocab.id_to_token.size();
+    if ((vocabSize == 70144) || (vocabSize == 70656))
     {
         return FINETUNE_OPENBUDDY;
     }


### PR DESCRIPTION
Hi!

Our new model has expanded vocab to 70656. We would like to add this vocab size in the model detection logic.