### PR TITLE
falcon_quantize: fix tokenizer.json path issue #1

### DIFF
--- a/libfalcon.cpp
+++ b/libfalcon.cpp
@@ -885,8 +885,15 @@ struct falcon_file_loader {
             fprintf(stderr, "falcon.cpp: fallback for old file format. Loading BPE merges from tokenizer.json\n");
             std::string fname_str(fname);
             size_t last_slash_idx = fname_str.find_last_of("\\/");
-            std::string parent_path = fname_str.substr(0, last_slash_idx);
-            std::string tokenizer_json_path = parent_path + "/tokenizer.json";
+            std::string parent_path;
+            if (last_slash_idx != std::string::npos) {
+                // slash was found, include original slash in path
+                parent_path = fname_str.substr(0, last_slash_idx +1);
+            } else {
+                // No slash found, the fname is the filename itself
+                parent_path = "";
+            }
+            std::string tokenizer_json_path = parent_path + "tokenizer.json";
             auto merges = vocab.parse_json_to_bpe_merges(tokenizer_json_path);
             if (merges.empty()) {
                 fprintf(stderr, "falcon.cpp: error: old file format. Place json data in directory: %s\n", tokenizer_json_path.c_str());


### PR DESCRIPTION
As described in problem #1 and discussion #80, it is not possible to quantize a converted f32.bin under Windows when falcon_quantize is run from the directory where the f32.bin file is located.
In this case, the filename is passed as a relative path that contains nothing but the filename. Therefore, cutting the path by searching for the last `\` or `/` fails, leaving the filename as the "path" to which the /tokenizer.json is appended. So the program does not search in the same directory as the filename, but in a subdirectory with the same name as the file. A simple hack would be to put the tokenizer.json in an appropriately named subdirectory, but on Windows it is not possible to name a directory with the same name as a file in that directory.

This PR fixes that problem and allows the program to find the tokenizer.json in the same directory as the file.
